### PR TITLE
Replace header question mark with pizza logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pizzaria Miragem - Vila do Conde</title>
     
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23e74c3c'%3E%3Cpath d='M12.16 3.13c-.84 0-1.54.29-2.35.8a6.6 6.6 0 0 0-1.8 2.04A8.3 8.3 0 0 0 7.17 8.8c-.39 1.32-.39 2.82.23 4.37.63 1.55 1.78 3.01 3.6 3.88 1.82.87 3.74.87 5.56 0 1.82-.87 2.97-2.33 3.6-3.88.62-1.55.62-3.05.23-4.37a8.3 8.3 0 0 0-.84-2.83 6.6 6.6 0 0 0-1.8-2.04c-.81-.51-1.51-.8-2.35-.8zm-.16 2c.42 0 .8.18 1.17.48.38.3.7.7.94 1.15.24.45.4.93.46 1.4.06.46.02.9-.15 1.26-.17.36-.46.64-.83.8-.37.16-.81.2-1.24.11a2.86 2.86 0 0 1-1.15-.46 2.6 2.6 0 0 1-.8-.94 2.4 2.4 0 0 1-.11-1.24c.05-.43.2-.87.46-1.26.26-.4.58-.74.94-1.0.36-.26.74-.3 1.17-.3z'/%3E%3Ccircle cx='8.5' cy='10.5' r='1' fill='%23f39c12'/%3E%3Ccircle cx='15.5' cy='9' r='0.8' fill='%23e67e22'/%3E%3Ccircle cx='13' cy='13' r='0.6' fill='%23d35400'/%3E%3Ccircle cx='9' cy='13.5' r='0.7' fill='%23f1c40f'/%3E%3C/svg%3E">
+    
     <!-- Preload critical resources -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -227,7 +230,7 @@
             <div class="header-content">
                 <div class="logo">
                     <div class="logo-icon">
-                        <i class="fas fa-palm-tree"></i>
+                        <i class="fas fa-pizza-slice"></i>
                     </div>
                     <div>
                         <h1>Pizzaria Miragem</h1>


### PR DESCRIPTION
Replace header icon and add favicon to display pizza logos.

The '?' in the header was likely a missing favicon, which has been added as an inline SVG pizza. Additionally, the existing palm tree icon in the header was replaced with a pizza slice for consistent branding.